### PR TITLE
Fix Go install

### DIFF
--- a/roles/workstation/tasks/go.yml
+++ b/roles/workstation/tasks/go.yml
@@ -15,6 +15,13 @@
         checksum: "{{ go.checksum }}"
       when: go_version_installed.stdout is not search(go.version)
 
+    - name: remove existing Go installation
+      become: true
+      ansible.builtin.file:
+        path: "/usr/local/go"
+        state: absent
+      when: go_version_installed is not search(go.version)
+
     - name: extract Go archive
       become: true
       ansible.builtin.unarchive:

--- a/roles/workstation/tasks/shell.yml
+++ b/roles/workstation/tasks/shell.yml
@@ -23,6 +23,7 @@
     owner: "{{ ansible_user_id }}"
   with_items:
     - zshrc
+    - zshenv
 
 - name: set zsh as default shell
   become: true

--- a/roles/workstation/templates/zshenv.j2
+++ b/roles/workstation/templates/zshenv.j2
@@ -1,0 +1,4 @@
+path+=(
+    "/usr/local/go/bin"
+    "$HOME/go/bin"
+    )

--- a/roles/workstation/templates/zshrc.j2
+++ b/roles/workstation/templates/zshrc.j2
@@ -1,5 +1,3 @@
-path+=("/usr/local/go/bin")
-
 alias vim="nvim"
 
 source $HOME/.antidote/antidote.zsh


### PR DESCRIPTION
Remove existing Go installation when installing a new version.

Before, Go tarball was extracted but existing files were left untouched. This caused all sorts of issues with stdlib.